### PR TITLE
Port implementation to use proc-macro-hack crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,20 @@
 [package]
 
 name = "fourcc"
-version = "0.0.4"
+version = "0.1.0"
 authors = ["The Rust Project Developers"]
 
+readme = "README.md"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang/fourcc"
 homepage = "https://github.com/rust-lang/fourcc"
-keywords = ["plugin", "macro"]
+keywords = ["macro","fourcc"]
 description = """
-Syntax extension to generate FourCCs (four-character code).
+A macro to generate FourCCs (four-character code).
 """
 
-[lib]
+[dependencies]
+fourcc-impl = { version = "0.1", path = "./fourcc-impl" }
+proc-macro-hack = "0.4"
 
-name = "fourcc"
-plugin = true
+[workspace]

--- a/README.md
+++ b/README.md
@@ -1,23 +1,78 @@
+# Example
+
+```rust
+#[macro_use]
+extern crate fourcc;
+
+fn main() {
+    assert_eq!(fourcc!("asys"), 0x61737973);
+    assert_eq!(fourcc!("asys", big), 0x61737973);
+    assert_eq!(fourcc!("asys", little), 0x73797361);
+
+    if cfg!(target_endian = "big") {
+        assert_eq!(fourcc!("asys", target), 0x61737973);
+    } else {
+        assert_eq!(fourcc!("asys", target), 0x73797361);
+    }
+```
+
 fourcc
 ======
 
-A Rust syntax extension to generate FourCCs.
+A Rust proc macro to generate FourCCs.
 
 [![Build Status](https://travis-ci.org/rust-lang/fourcc.svg?branch=master)](https://travis-ci.org/rust-lang/fourcc)
 
-## Usage
 
-Add this to your `Cargo.toml`:
+This crate provides a `fourcc!` macro for expressing FourCC values
+`fourcc!("asys")` in the place of integer literals.
+
+The `fourcc!` macro accepts a 4 character string literal which will be
+converted into a `u32` treating each character as a `u8`.
+
+The order of the resulting `u32` is controlled by an optional,
+comma-separated keyword following the string literal. Keyword is one of:
+
+ * `big` - Big Endian ordering - ie `"ABCD"` -> `0xaabbccdd`,
+ * `little` - Little Endian ordering - ie `"ABCD"` -> `0xddccbbaa`,
+ * `target` - Endian of target.
+
+The default ordering is `big` endian.
+
+# Usage
+
+Add this to you `Cargo.toml`
 
 ```toml
 [dependencies]
-
-fourcc = "*"
+fourcc = "0.1"
 ```
 
 and this to your crate root:
 
 ```rust
-#![feature(plugin)]
-#![plugin(fourcc)]
+#[macro_use]
+extern crate fourcc;
 ```
+
+# Compatability
+
+This crate supports all versions of Rust (stable and nightly) starting
+with Rust 1.15.
+
+# License
+
+Licensed under either of
+
+ * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opersource.org/licenses/MIT)
+ 
+at your option.
+
+# Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the
+Apache-2.0 license, shall be dual licensed as about, without any
+additional terms or conditions.
+

--- a/README.md
+++ b/README.md
@@ -1,21 +1,3 @@
-# Example
-
-```rust
-#[macro_use]
-extern crate fourcc;
-
-fn main() {
-    assert_eq!(fourcc!("asys"), 0x61737973);
-    assert_eq!(fourcc!("asys", big), 0x61737973);
-    assert_eq!(fourcc!("asys", little), 0x73797361);
-
-    if cfg!(target_endian = "big") {
-        assert_eq!(fourcc!("asys", target), 0x61737973);
-    } else {
-        assert_eq!(fourcc!("asys", target), 0x73797361);
-    }
-```
-
 fourcc
 ======
 
@@ -38,6 +20,24 @@ comma-separated keyword following the string literal. Keyword is one of:
  * `target` - Endian of target.
 
 The default ordering is `big` endian.
+
+# Example
+
+```rust
+#[macro_use]
+extern crate fourcc;
+
+fn main() {
+    assert_eq!(fourcc!("asys"), 0x61737973);
+    assert_eq!(fourcc!("asys", big), 0x61737973);
+    assert_eq!(fourcc!("asys", little), 0x73797361);
+
+    if cfg!(target_endian = "big") {
+        assert_eq!(fourcc!("asys", target), 0x61737973);
+    } else {
+        assert_eq!(fourcc!("asys", target), 0x73797361);
+    }
+```
 
 # Usage
 

--- a/fourcc-impl/Cargo.toml
+++ b/fourcc-impl/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fourcc-impl"
+description = "Implementation crate for the procedural fourcc! macro."
+version = "0.1.0"
+authors = [ "The Rust Project Developers" ]
+repository = "https://github.com/rust-lang/fourcc"
+homepage = "https://github.com/rust-lang/fourcc"
+license = "MIT/Apache-2.0"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro-hack = "0.4"
+syn = "0.12"

--- a/fourcc-impl/LICENSE-APACHE
+++ b/fourcc-impl/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/fourcc-impl/LICENSE-MIT
+++ b/fourcc-impl/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/fourcc-impl/src/lib.rs
+++ b/fourcc-impl/src/lib.rs
@@ -1,0 +1,78 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate proc_macro_hack;
+#[macro_use]
+extern crate syn;
+
+use syn::synom::Synom;
+
+struct FourCC {
+    pub lit: syn::LitStr,
+    pub endian: Option<syn::Ident>,
+}
+
+impl Synom for FourCC {
+    named!(parse -> Self, do_parse!(
+        lit: syn!(syn::LitStr) >>
+        endian: option!(do_parse!(punct!(,) >> id: syn!(syn::Ident) >> (id))) >>
+            (FourCC { lit, endian })
+    ));
+}
+
+fn convert(fcc: FourCC) -> String {
+    let little = match fcc.endian {
+        None => false,
+        Some(id) => match id.as_ref() {
+            "little" => true,
+            "big" => false,
+            "target" => target_little_endian(),
+            x => panic!("invalid endian directive `{}` in fourcc!", x),
+        },
+    };
+
+    if fcc.lit.value().chars().count() != 4 {
+        panic!("string literal `{:?}` len != 4 in fourcc!", fcc.lit.value());
+    }
+
+    let mut val = 0u32;
+    for codepoint in fcc.lit.value().chars().take(4) {
+        let byte = if codepoint as u32 > 0xFF {
+            panic!("fourcc! literal character out of range 0-255");
+        } else {
+            codepoint as u8
+        };
+
+        val = if little {
+            (val >> 8) | ((byte as u32) << 24)
+        } else {
+            (val << 8) | (byte as u32)
+        };
+    }
+    format!("{}", val)
+}
+
+fn target_little_endian() -> bool {
+    if cfg!(target_endian = "little") {
+        true
+    } else {
+        false
+    }
+}
+
+proc_macro_expr_impl! {
+    pub fn fourcc_impl(input: &str) -> String {
+        match syn::parse_str(input) {
+            Ok(fcc) => convert(fcc),
+            Err(e) => panic!("fourcc! failed: {}", e),
+        }
+    }
+}

--- a/tests/example.rs
+++ b/tests/example.rs
@@ -1,0 +1,17 @@
+#[macro_use]
+extern crate fourcc;
+
+#[test]
+fn basic() {
+    assert_eq!(fourcc!("asys"), 0x61737973);
+}
+
+#[test]
+fn big_endian() {
+    assert_eq!(fourcc!("asys", big), 0x61737973);
+}
+
+#[test]
+fn little_endian() {
+    assert_eq!(fourcc!("asys", little), 0x73797361);
+}


### PR DESCRIPTION
I couldn't find an alternative to this "deprecated" crate on crates.io, so I ported the implementation to use `proc-macro-hack` allowing it to live on.